### PR TITLE
declarative: add WithPreserveNamespace option

### DIFF
--- a/alpha/patterns/addon/examples/dashboard-operator/pkg/controller/dashboard/dashboard_controller.go
+++ b/alpha/patterns/addon/examples/dashboard-operator/pkg/controller/dashboard/dashboard_controller.go
@@ -47,6 +47,7 @@ func Add(mgr manager.Manager) error {
 		declarative.WithOwner(declarative.SourceAsOwner),
 		declarative.WithLabels(declarative.SourceLabel),
 		declarative.WithStatus(status.NewBasic(mgr.GetClient())),
+		declarative.WithPreserveNamespace(),
 	)
 
 	c, err := controller.New("dashboard-controller", mgr, controller.Options{Reconciler: r})

--- a/alpha/patterns/addon/pkg/status/aggregate.go
+++ b/alpha/patterns/addon/pkg/status/aggregate.go
@@ -47,7 +47,7 @@ func (a *aggregator) Reconciled(ctx context.Context, src declarative.Declarative
 		case "extensions/Deployment", "apps/Deployment":
 			healthy, err = a.deployment(ctx, instance, o.Name)
 		default:
-			log.WithValues("type", gk).Info("type not implemented for status aggregation, skipping")
+			log.WithValues("type", gk).V(2).Info("type not implemented for status aggregation, skipping")
 		}
 
 		status.Healthy = status.Healthy && healthy

--- a/alpha/patterns/declarative/options.go
+++ b/alpha/patterns/declarative/options.go
@@ -18,6 +18,8 @@ type reconcilerParams struct {
 	manifestController    ManifestController
 
 	//prune bool
+	preserveNamespace bool
+
 	sink       Sink
 	ownerFn    OwnerSelector
 	labelMaker LabelMaker
@@ -164,6 +166,15 @@ func WithLabels(labelMaker LabelMaker) reconcilerOption {
 func WithStatus(status Status) reconcilerOption {
 	return func(p reconcilerParams) reconcilerParams {
 		p.status = status
+		return p
+	}
+}
+
+// WithPreserveNamespace preserves the namespaces defined in the deployment manifest
+// instead of matching the namespace of the DeclarativeObject
+func WithPreserveNamespace() reconcilerOption {
+	return func(p reconcilerParams) reconcilerParams {
+		p.preserveNamespace = true
 		return p
 	}
 }

--- a/alpha/patterns/declarative/pkg/watch/dynamic.go
+++ b/alpha/patterns/declarative/pkg/watch/dynamic.go
@@ -54,7 +54,7 @@ func (dw *dynamicWatch) Add(trigger schema.GroupVersionKind, options metav1.List
 
 	client, err := dw.newDynamicClient(trigger)
 	if err != nil {
-		fmt.Errorf("creating client for (%s): %v", trigger.String(), err)
+		return fmt.Errorf("creating client for (%s): %v", trigger.String(), err)
 	}
 
 	events, err := client.Watch(options)

--- a/alpha/patterns/declarative/reconciler.go
+++ b/alpha/patterns/declarative/reconciler.go
@@ -258,7 +258,7 @@ func (r *Reconciler) injectOwnerRef(ctx context.Context, instance DeclarativeObj
 	}
 
 	log := log.Log
-	log.WithValues("object", instance).Info("injecting owner references")
+	log.WithValues("object", fmt.Sprintf("%s/%s", instance.GetName(), instance.GetNamespace())).Info("injecting owner references")
 
 	for _, o := range objects.Items {
 		owner, err := r.options.ownerFn(ctx, instance, *o, *objects)

--- a/alpha/patterns/declarative/reconciler.go
+++ b/alpha/patterns/declarative/reconciler.go
@@ -149,7 +149,12 @@ func (r *Reconciler) reconcileExists(ctx context.Context, name types.NamespacedN
 			}
 	*/
 
-	if err := r.kubectl.Apply(ctx, name.Namespace, m, extraArgs...); err != nil {
+	ns := ""
+	if !r.options.preserveNamespace {
+		ns = name.Namespace
+	}
+
+	if err := r.kubectl.Apply(ctx, ns, m, extraArgs...); err != nil {
 		log.Error(err, "applying manifest")
 		return reconcile.Result{}, fmt.Errorf("error applying manifest: %v", err)
 	}
@@ -197,6 +202,7 @@ func (r *Reconciler) BuildDeploymentObjects(ctx context.Context, name types.Name
 	if r.options.labelMaker != nil {
 		transforms = append(transforms, AddLabels(r.options.labelMaker(ctx, instance)))
 	}
+	// TODO(jrjohnson): apply namespace here
 	for _, t := range transforms {
 		err := t(ctx, instance, objects)
 		if err != nil {

--- a/alpha/patterns/declarative/sort.go
+++ b/alpha/patterns/declarative/sort.go
@@ -31,7 +31,7 @@ func DefaultObjectOrder(ctx context.Context) func(o *manifest.Object) int {
 			return 100
 
 		// Create the pods after we've created other things they might be waiting for
-		case "extensions/Deployment", "app/Deployment":
+		case "extensions/Deployment", "apps/Deployment":
 			return 1000
 
 		// Autoscalers typically act on a deployment
@@ -43,8 +43,7 @@ func DefaultObjectOrder(ctx context.Context) func(o *manifest.Object) int {
 			return 10000
 
 		default:
-			// TODO: Downgrade to V(2) once we're more comfortable with the ordering
-			log.WithValues("group", o.Group).WithValues("kind", o.Kind).Info("unknown group / kind")
+			log.WithValues("group", o.Group).WithValues("kind", o.Kind).V(2).Info("unknown group / kind")
 			return 1000
 		}
 	}


### PR DESCRIPTION
This option prevents the Reconciler from deploying all objects in the
same namespace as the DeclarativeObject.

Generally, we do want the namespace behavior because it makes things
like OwnerRef's work, but there are exceptions that need to control this
themselves.